### PR TITLE
管理者認証と保護ルートの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+#プロジェクト概要
+
+ポートフォリオサイトです。
+
+```
 📦 my-portfolio/
 ├── frontend/
 │ ├── src/
@@ -6,3 +11,34 @@
 │ ├── prisma/
 │ └── src/
 └── README.md
+```
+
+## システム構成図
+
+```
+ユーザー
+|
+▼
+ブラウザ（http://localhost:3000）
+|　
+▼
+フロントエンド(Next.js,TypeScript)
+| ❶ ログイン・サインアップ作業
+▼
+Firebase Authentication
+| ❷ 認証処理（Google）
+| ❸ ID トークン取得
+▼
+フロントエンド
+| ❹ APIリクエスト時にIDトークンをAuthorizationヘッダー
+▼
+バックエンド(Express.js,TypeScript)(@http://localhost:3001)
+| ❺ Firebase AdminSDK で ID トークン検証
+| ❻ ユーザー情報取得・認可判定
+| ❼ データー操作リクエスト
+▼
+Prisma ORM
+| ❽ 生成・実行
+▼
+MySQL(データ保存)
+```

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .history/
 /src/generated/prisma
 serviceAccountKey.json/
+/scripts/

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@
 import express from "express";
 import cors from "cors";
 import authRouter from "./routers/authRouter";
+import adminRouter from "./routers/adminRouter";
 
 const app = express();
 // フロントエンドの http://localhost:3000 を許可
@@ -15,5 +16,6 @@ app.use(
 app.use(express.json());
 
 app.use("/api/auth", authRouter); // ← ここで /me が /api/auth/me にマウントされる
+app.use("/api/admin", adminRouter);
 
 export default app;

--- a/backend/src/middleware/isAdmin.ts
+++ b/backend/src/middleware/isAdmin.ts
@@ -1,0 +1,13 @@
+// backend/src/middleware/isAdmin.ts（管理者か判断）
+import { Request, Response, NextFunction } from "express";
+import { DecodedIdToken } from "firebase-admin/auth";
+
+export const isAdmin = (req: Request, res: Response, next: NextFunction) => {
+  const user = (req as { user?: DecodedIdToken }).user;
+
+  if (user?.isAdmin) {
+    next(); // 管理者 → 通過
+  } else {
+    res.status(403).json({ message: "管理者権限がありません" });
+  }
+};

--- a/backend/src/middleware/verifyFirebaseToken.ts
+++ b/backend/src/middleware/verifyFirebaseToken.ts
@@ -1,4 +1,4 @@
-// backend/src/middleware/verifyFirebaseToken.ts
+// backend/src/middleware/verifyFirebaseToken.ts（有効なトークンかどうか）
 import { Request, Response, NextFunction } from "express";
 import { adminAuth } from "../libs/firebaseAdmin";
 import { DecodedIdToken } from "firebase-admin/auth"; // ← 追加（型）

--- a/backend/src/routers/adminRouter.ts
+++ b/backend/src/routers/adminRouter.ts
@@ -1,0 +1,18 @@
+// backend/src/routers/adminRouter.ts（管理者用）
+import { Router, Request, Response } from "express";
+import { verifyFirebaseToken } from "../middleware/verifyFirebaseToken";
+import { isAdmin } from "../middleware/isAdmin"; // ← ミドルウェア
+
+const router = Router();
+
+// 管理者だけがアクセスできる秘密のエンドポイント
+router.get(
+  "/secret",
+  verifyFirebaseToken, // 認証チェック
+  isAdmin, // 管理者チェック
+  (req: Request, res: Response) => {
+    res.json({ message: "管理者だけが見れるデータです " });
+  }
+);
+
+export default router;

--- a/backend/src/routers/authRouter.ts
+++ b/backend/src/routers/authRouter.ts
@@ -1,4 +1,4 @@
-// backend/src/routers/authRouter.ts
+// backend/src/routers/authRouter.ts（基本情報取得）
 import express from "express";
 import { verifyFirebaseToken } from "../middleware/verifyFirebaseToken";
 import { DecodedIdToken } from "firebase-admin/auth";

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,38 @@
+"use client"; //管理者のみ
+
+import { useEffect, useState } from "react";
+import { getAuth } from "firebase/auth";
+import { app } from "@/libs/firebase";
+import { notFound } from "next/navigation";
+
+export default function AdminPage() {
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    const auth = getAuth(app);
+    const user = auth.currentUser;
+
+    if (!user) {
+      notFound(); // ログインしてない人は 404
+      return;
+    }
+
+    user.getIdTokenResult().then((idTokenResult) => {
+      const isAdmin = idTokenResult.claims.admin === true;
+      if (!isAdmin) {
+        notFound(); // 管理者じゃない人も 404
+      } else {
+        setChecked(true); // 管理者 OK
+      }
+    });
+  }, []);
+
+  if (!checked) return null;
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-12">
+      <h1 className="text-3xl font-bold mb-6">管理者専用ページ</h1>
+      <p>ここには管理者だけが見られる情報が表示されます。</p>
+    </main>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { getAuth } from "firebase/auth";
 import { app } from "@/libs/firebase"; // あなたが作ったfirebase.tsの初期化ファイル
-import Image from "next/image";
+import Image from "next/image"; //画像
 
 export default function Home() {
   const [apiResult, setApiResult] = useState<{


### PR DESCRIPTION
- 取得したIDトークンをAPIリクエストに付与
- 管理者ユーザーにカスタムクレーム付与
- 管理者権限ミドルウェア実装（isAdmin）
-  管理APIルーターに管理者チェック追加
- フロントエンドで保護されたルート（管理画面）を制御 

